### PR TITLE
Add initial game grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Clone this repository and execute the following command to run
 
 `cargo run`
 
+Use the following command to run tests
+
+`cargo test`
+
 ## References
 
 [Conway's Game of Life's Wikipedia](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life) 

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -101,7 +101,7 @@ fn index_no_overflow_add(i: i32, squares: u32) -> i32{
     }
 }
 
-
+#[cfg(test)]
 mod tests {
     use super::update_game_grid;
     use super::GameGrid;

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -1,15 +1,19 @@
 #[derive(Clone,Eq,PartialEq,Copy)]
 pub enum State{
+    // Describes the 2 possible states of a Cell in the Grid
     Alive,
     Dead
 }
 
 pub struct GameGrid {
+    // Represents the squared grid of size squares
     pub squares: u32,
     pub state: Vec<Vec<State>>
 }
 
 pub fn create_initial_game_grid(squares:u32) -> GameGrid{
+    // Creates an initial grid of size squares
+    // Right now the grid is harcoded as vertical lines, one dead an one alive, later this will be changed
     let mut state = vec![];
     for i in 0..squares {
         if i % 2 == 0 {
@@ -22,6 +26,7 @@ pub fn create_initial_game_grid(squares:u32) -> GameGrid{
 }
 
 pub fn update_game_grid(game_grid: &GameGrid) -> GameGrid{
+    // Update the grid state based on game of lifes rules, returns the new state
     let mut new_game_grid = create_initial_game_grid(game_grid.squares);
     for i in 0..game_grid.squares {
         for j in 0..game_grid.squares {
@@ -34,5 +39,6 @@ pub fn update_game_grid(game_grid: &GameGrid) -> GameGrid{
 }
 
 fn get_new_state(i: usize,j: usize,grid: &GameGrid) -> State {
+    // Given a cell, returns the new state based on game of lifes rules, WIP
     grid.state[i][j]
 }

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -1,15 +1,22 @@
+#[derive(Clone,Eq,PartialEq)]
+pub enum State{
+    Alive,
+    Dead
+}
+
 pub struct GameGrid {
-    pub state: Vec<Vec<bool>>
+    pub squares: u32,
+    pub state: Vec<Vec<State>>
 }
 
 pub fn create_initial_game_grid(squares:u32) -> GameGrid{
     let mut state = vec![];
     for i in 0..squares {
         if i % 2 == 0 {
-            state.push(vec![false;squares as usize]);
+            state.push(vec![State::Dead;squares as usize]);
         } else {
-            state.push(vec![true;squares as usize]);
+            state.push(vec![State::Alive;squares as usize]);
         }
     }
-    GameGrid{state}
+    GameGrid{squares,state}
 }

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -1,4 +1,4 @@
-#[derive(Clone,Eq,PartialEq)]
+#[derive(Clone,Eq,PartialEq,Copy)]
 pub enum State{
     Alive,
     Dead
@@ -19,4 +19,20 @@ pub fn create_initial_game_grid(squares:u32) -> GameGrid{
         }
     }
     GameGrid{squares,state}
+}
+
+pub fn update_game_grid(game_grid: &GameGrid) -> GameGrid{
+    let mut new_game_grid = create_initial_game_grid(game_grid.squares);
+    for i in 0..game_grid.squares {
+        for j in 0..game_grid.squares {
+            let new_state = get_new_state(i as usize,j as usize,&game_grid);
+            new_game_grid.state[i as usize][j as usize] = new_state;
+        }
+    }
+
+    new_game_grid
+}
+
+fn get_new_state(i: usize,j: usize,grid: &GameGrid) -> State {
+    grid.state[i][j]
 }

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -1,4 +1,4 @@
-#[derive(Clone,Eq,PartialEq,Copy)]
+#[derive(Clone,Eq,PartialEq,Copy,Debug)]
 pub enum State{
     // Describes the 2 possible states of a Cell in the Grid
     Alive,
@@ -13,13 +13,13 @@ pub struct GameGrid {
 
 pub fn create_initial_game_grid(squares:u32) -> GameGrid{
     // Creates an initial grid of size squares
-    // Right now the grid is harcoded as vertical lines, one dead an one alive, later this will be changed
+    // Right now the grid is harcoded as vertical lines, one alives an two dead, later this will be changed
     let mut state = vec![];
     for i in 0..squares {
-        if i % 2 == 0 {
-            state.push(vec![State::Dead;squares as usize]);
-        } else {
+        if i % 3 == 0 {
             state.push(vec![State::Alive;squares as usize]);
+        } else {
+            state.push(vec![State::Dead;squares as usize]);
         }
     }
     GameGrid{squares,state}
@@ -99,4 +99,149 @@ fn index_no_overflow_add(i: i32, squares: u32) -> i32{
     } else {
         i + 1
     }
+}
+
+
+mod tests {
+    use super::update_game_grid;
+    use super::GameGrid;
+    use super::State;
+
+    #[test]
+    fn test_update_game_grid_all_dead(){
+        let squares = 4;
+        let state = vec![
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+        ];
+
+        let game_grid = GameGrid{squares,state};
+
+        let new_game_grid = update_game_grid(&game_grid);
+
+        assert_eq!(game_grid.state,new_game_grid.state);
+    }
+
+
+    #[test]
+    fn test_update_game_grid_all_alive(){
+        let squares = 4;
+        let state = vec![
+            vec![State::Alive,State::Alive,State::Alive,State::Alive],
+            vec![State::Alive,State::Alive,State::Alive,State::Alive],
+            vec![State::Alive,State::Alive,State::Alive,State::Alive],
+            vec![State::Alive,State::Alive,State::Alive,State::Alive],
+        ];
+
+        let game_grid = GameGrid{squares,state};
+
+        let new_game_grid = update_game_grid(&game_grid);
+        
+        let result_grid_state = vec![
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+        ];
+        assert_eq!(result_grid_state,new_game_grid.state);
+    }
+
+    #[test]
+    fn test_update_game_grid_one_alive(){
+        let squares = 4;
+        let state = vec![
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Alive,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+        ];
+
+        let game_grid = GameGrid{squares,state};
+
+        let new_game_grid = update_game_grid(&game_grid);
+        
+        let result_grid_state = vec![
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+        ];
+        assert_eq!(result_grid_state,new_game_grid.state);
+    }
+
+    #[test]
+    fn test_update_game_grid_one_alive_stays_alive(){
+        let squares = 4;
+        let state = vec![
+            vec![State::Dead,State::Dead,State::Alive,State::Dead],
+            vec![State::Dead,State::Alive,State::Dead,State::Dead],
+            vec![State::Alive,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+        ];
+
+        let game_grid = GameGrid{squares,state};
+
+        let new_game_grid = update_game_grid(&game_grid);
+        
+        let result_grid_state = vec![
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Alive,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead],
+        ];
+        assert_eq!(result_grid_state,new_game_grid.state);
+    }
+
+    #[test]
+    fn test_update_game_grid_dead_with_3_alive_neighbours_is_alive(){
+        let squares = 5;
+        let state = vec![
+            vec![State::Dead,State::Alive,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Alive,State::Dead,State::Alive,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead,State::Dead],
+        ];
+
+        let game_grid = GameGrid{squares,state};
+
+        let new_game_grid = update_game_grid(&game_grid);
+        
+        let result_grid_state = vec![
+            vec![State::Dead,State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Alive,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead,State::Dead],
+        ];
+        assert_eq!(result_grid_state,new_game_grid.state);
+    }
+
+    #[test]
+    fn test_update_game_grid_glider(){
+        let squares = 5;
+        let state = vec![
+            vec![State::Dead,State::Alive,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Alive,State::Dead,State::Dead],
+            vec![State::Alive,State::Alive,State::Alive,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead,State::Dead],
+        ];
+
+        let game_grid = GameGrid{squares,state};
+
+        let new_game_grid = update_game_grid(&game_grid);
+        
+        let result_grid_state = vec![
+            vec![State::Dead,State::Dead,State::Dead,State::Dead,State::Dead],
+            vec![State::Alive,State::Dead,State::Alive,State::Dead,State::Dead],
+            vec![State::Dead,State::Alive,State::Alive,State::Dead,State::Dead],
+            vec![State::Dead,State::Alive,State::Dead,State::Dead,State::Dead],
+            vec![State::Dead,State::Dead,State::Dead,State::Dead,State::Dead],
+        ];
+        assert_eq!(result_grid_state,new_game_grid.state);
+    }
+
 }

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -1,0 +1,15 @@
+pub struct GameGrid {
+    pub state: Vec<Vec<bool>>
+}
+
+pub fn create_initial_game_grid(squares:u32) -> GameGrid{
+    let mut state = vec![];
+    for i in 0..squares {
+        if i % 2 == 0 {
+            state.push(vec![false;squares as usize]);
+        } else {
+            state.push(vec![true;squares as usize]);
+        }
+    }
+    GameGrid{state}
+}

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -13,7 +13,7 @@ pub struct GameGrid {
 
 pub fn create_initial_game_grid(squares:u32) -> GameGrid{
     // Creates an initial grid of size squares
-    // Right now the grid is harcoded as vertical lines, one alives an two dead, later this will be changed
+    // Right now the grid is harcoded as vertical lines, one alives an two deadg, later this will be changed
     let mut state = vec![];
     for i in 0..squares {
         if i % 3 == 0 {
@@ -39,7 +39,7 @@ pub fn update_game_grid(game_grid: &GameGrid) -> GameGrid{
 }
 
 fn get_new_state(i: usize,j: usize,grid: &GameGrid) -> State {
-    // Given a cell, returns the new state based on game of lifes rules, WIP
+    // Given a cell, returns the new state based on game of lifes rules
     let alive_neighbours = get_alive_neighbours(i,j,grid);
     if grid.state[i][j] == State::Dead && alive_neighbours == 3 {
         State::Alive

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -40,5 +40,63 @@ pub fn update_game_grid(game_grid: &GameGrid) -> GameGrid{
 
 fn get_new_state(i: usize,j: usize,grid: &GameGrid) -> State {
     // Given a cell, returns the new state based on game of lifes rules, WIP
-    grid.state[i][j]
+    let alive_neighbours = get_alive_neighbours(i,j,grid);
+    if grid.state[i][j] == State::Dead && alive_neighbours == 3 {
+        State::Alive
+    } else if grid.state[i][j] == State::Alive && (alive_neighbours == 2 || alive_neighbours == 3) {
+        State::Alive
+    } else {
+        State::Dead
+    }
+}
+
+fn get_alive_neighbours(i: usize, j: usize, grid: &GameGrid) -> u32 {
+    // Returns the number of alive neighbours for a given cell in the grid
+
+    let mut alive_neighbours = 0;
+
+    if grid.state[index_no_overflow_sub(i as i32, grid.squares) as usize][j] == State::Alive {
+        alive_neighbours += 1;
+    }
+    if grid.state[index_no_overflow_add(i as i32, grid.squares) as usize][j] == State::Alive {
+        alive_neighbours += 1;
+    }
+    if grid.state[i][index_no_overflow_add(j as i32, grid.squares) as usize] == State::Alive {
+        alive_neighbours += 1;
+    }
+    if grid.state[i][index_no_overflow_sub(j as i32, grid.squares) as usize] == State::Alive {
+        alive_neighbours += 1;
+    }
+    if grid.state[index_no_overflow_sub(i as i32, grid.squares) as usize][index_no_overflow_add(j as i32, grid.squares) as usize] == State::Alive {
+        alive_neighbours += 1;
+    }
+    if grid.state[index_no_overflow_sub(i as i32, grid.squares) as usize][index_no_overflow_sub(j as i32, grid.squares) as usize] == State::Alive {
+        alive_neighbours += 1;
+    }
+    if grid.state[index_no_overflow_add(i as i32, grid.squares) as usize][index_no_overflow_sub(j as i32, grid.squares) as usize] == State::Alive {
+        alive_neighbours += 1;
+    }
+    if grid.state[index_no_overflow_add(i as i32, grid.squares) as usize][index_no_overflow_add(j as i32, grid.squares) as usize] == State::Alive {
+        alive_neighbours += 1;
+    } // TODO make this less ugly
+
+    alive_neighbours
+}
+
+fn index_no_overflow_sub(i: i32,squares: u32) -> i32 {
+    // Returns sub of i and 1 bounded by squares
+    if (i - 1) < 0 {
+        (squares - 1) as i32
+    } else {
+        i-1
+    }
+}
+
+fn index_no_overflow_add(i: i32, squares: u32) -> i32{
+    // Returns add of i and 1 bounded by squares
+    if (i + 1) > (squares - 1) as i32 {
+        0
+    } else {
+        i + 1
+    }
 }

--- a/src/graphical_interface.rs
+++ b/src/graphical_interface.rs
@@ -3,12 +3,14 @@ use macroquad::prelude::*;
 use crate::game_logic::{GameGrid,State};
 
 struct Grid {
+    // Represents the grid on a graphical level
     offset_x: f32,
     offset_y: f32,
     sq_size: f32
 }
 
 fn get_grid(squares: u32) -> Grid {
+    // Returns the graphical grid
     let game_size = screen_width().min(screen_height());
     let offset_x = (screen_width() - game_size) / 2. + 10.;
     let offset_y = (screen_height() - game_size) / 2. + 10.;
@@ -18,6 +20,7 @@ fn get_grid(squares: u32) -> Grid {
 }
 
 async fn draw_grid_outline(squares: u32) {
+    // Draws the grid lines on screen
     let grid = get_grid(squares);
 
     for i in 0..squares+1 {
@@ -44,12 +47,14 @@ async fn draw_grid_outline(squares: u32) {
 }
 
 async fn fill_square(i: u32, j:u32,squares:u32 ) {
+    // Fills a cell black given its index
     let grid = get_grid(squares);
 
     draw_rectangle(grid.offset_x + grid.sq_size * i as f32, grid.offset_y + grid.sq_size * j as f32, grid.sq_size, grid.sq_size, BLACK);
 }
 
 pub async fn draw_grid(grid: &GameGrid) {
+    // Draws the entire grid given its current state
     draw_grid_outline(grid.squares).await;
     for (i,row) in grid.state.iter().enumerate() {
         for (j,state) in row.iter().enumerate() {

--- a/src/graphical_interface.rs
+++ b/src/graphical_interface.rs
@@ -1,5 +1,7 @@
 use macroquad::prelude::*;
 
+use crate::game_logic::{GameGrid,State};
+
 struct Grid {
     offset_x: f32,
     offset_y: f32,
@@ -15,7 +17,7 @@ fn get_grid(squares: u32) -> Grid {
     Grid{offset_x,offset_y,sq_size}
 }
 
-pub async fn create_grid(squares: u32) {
+async fn draw_grid_outline(squares: u32) {
     let grid = get_grid(squares);
 
     for i in 0..squares+1 {
@@ -41,9 +43,19 @@ pub async fn create_grid(squares: u32) {
     }
 }
 
-pub async fn fill_square(i: u32, j:u32,squares:u32 ) {
+async fn fill_square(i: u32, j:u32,squares:u32 ) {
     let grid = get_grid(squares);
 
     draw_rectangle(grid.offset_x + grid.sq_size * i as f32, grid.offset_y + grid.sq_size * j as f32, grid.sq_size, grid.sq_size, BLACK);
 }
 
+pub async fn draw_grid(grid: GameGrid) {
+    draw_grid_outline(grid.squares).await;
+    for (i,row) in grid.state.iter().enumerate() {
+        for (j,state) in row.iter().enumerate() {
+            if *state == State::Alive {
+                fill_square(i as u32, j as u32, grid.squares).await;
+            }
+        }
+    }
+}

--- a/src/graphical_interface.rs
+++ b/src/graphical_interface.rs
@@ -49,7 +49,7 @@ async fn fill_square(i: u32, j:u32,squares:u32 ) {
     draw_rectangle(grid.offset_x + grid.sq_size * i as f32, grid.offset_y + grid.sq_size * j as f32, grid.sq_size, grid.sq_size, BLACK);
 }
 
-pub async fn draw_grid(grid: GameGrid) {
+pub async fn draw_grid(grid: &GameGrid) {
     draw_grid_outline(grid.squares).await;
     for (i,row) in grid.state.iter().enumerate() {
         for (j,state) in row.iter().enumerate() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ use macroquad::prelude::*;
 mod graphical_interface;
 mod game_logic;
 
+use std::thread;
+use std::time;
 const SQUARES: u32 = 16;
 #[macroquad::main("Conways Game Of Life")]
 async fn main() {
@@ -11,6 +13,8 @@ async fn main() {
         
         graphical_interface::draw_grid(&game_grid).await;
         game_grid = game_logic::update_game_grid(&game_grid);
+
+        thread::sleep(time::Duration::from_millis(500));
         next_frame().await
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,15 @@
 use macroquad::prelude::*;
 mod graphical_interface;
+mod game_logic;
 
 const SQUARES: u32 = 16;
 #[macroquad::main("Conways Game Of Life")]
 async fn main() {
     loop {
         clear_background(WHITE);
-
-        graphical_interface::create_grid(SQUARES).await;
-
-        graphical_interface::fill_square(1,7,SQUARES).await;
-        graphical_interface::fill_square(3,9,SQUARES).await;
-        graphical_interface::fill_square(3,10,SQUARES).await;
-        graphical_interface::fill_square(4,9,SQUARES).await;
-        graphical_interface::fill_square(15,15,SQUARES).await;
-
+        
+        let game_grid = game_logic::create_initial_game_grid(SQUARES);
+        graphical_interface::draw_grid(game_grid).await;
         next_frame().await
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,8 @@ async fn main() {
         clear_background(WHITE);
         
         let game_grid = game_logic::create_initial_game_grid(SQUARES);
-        graphical_interface::draw_grid(game_grid).await;
+        graphical_interface::draw_grid(&game_grid).await;
+        game_logic::update_game_grid(&game_grid);
         next_frame().await
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,12 @@ mod game_logic;
 const SQUARES: u32 = 16;
 #[macroquad::main("Conways Game Of Life")]
 async fn main() {
+    let mut game_grid = game_logic::create_initial_game_grid(SQUARES);
     loop {
         clear_background(WHITE);
         
-        let game_grid = game_logic::create_initial_game_grid(SQUARES);
         graphical_interface::draw_grid(&game_grid).await;
-        game_logic::update_game_grid(&game_grid);
+        game_grid = game_logic::update_game_grid(&game_grid);
         next_frame().await
     }
 }


### PR DESCRIPTION
Added game logic, this include:

Creating an initial grid, rigth now it has a harcoded example, in the future it will accept a file as input

Updating the grid, given a game grid, it returns the next grid state following the conway's game of life rules

Expected execution:

<img width="619" alt="Captura de pantalla 2024-04-09 a la(s) 11 07 40 a  m" src="https://github.com/gianbelinche/Conways-Game-Of-Life/assets/39842759/ba47f399-d9e0-4d2e-9ab9-2c05957366d2">
<img width="611" alt="Captura de pantalla 2024-04-09 a la(s) 11 08 17 a  m" src="https://github.com/gianbelinche/Conways-Game-Of-Life/assets/39842759/3e85313a-7700-400a-9a77-cdc53cc8df1a">
<img width="648" alt="Captura de pantalla 2024-04-09 a la(s) 11 07 47 a  m" src="https://github.com/gianbelinche/Conways-Game-Of-Life/assets/39842759/b58bad32-6d56-450d-af65-fc13bd257d3d">

(Continues indefinitely)

